### PR TITLE
CI: Update CI builds

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,61 +1,39 @@
-name: Build DEB
+name: Build Debian packages
 
 on: [push, pull_request]
 
 jobs:
-  build-deb-buster:
-    name: Build DEB on Debian 10 Buster
+  build:
+    name: ${{ matrix.dist }}
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        dist: ['buster', 'bullseye', 'bookworm']
+
     steps:
-    - name: Checkout  
+    - name: Checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Update changelog
-      run: |
-        sudo apt-get update
-        sudo apt-get install cmake devscripts debhelper
-        debchange -v "`git describe --tags`-buster" -M --distribution buster "trunk build"
+
     - name: Build package
-      uses: nylas/build-dpkg-buster@v1
-      id: build
+      uses: jtdor/build-deb-action@v1
       with:
-        args: --unsigned-source --unsigned-changes -b
-    - name: Upload artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: ${{ steps.build.outputs.filename }}
-        path: ${{ steps.build.outputs.filename }}
-    - name: Upload dbgsym artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: ${{ steps.build.outputs.filename-dbgsym }}
-        path: ${{ steps.build.outputs.filename-dbgsym }}
-  #build-deb-bullseye:
-  #  name: Build DEB on Debian 11 Bullseye
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #  - uses: actions/checkout@v2
-  #    with:
-  #      fetch-depth: 0
-  #  - name: Update changelog
-  #    run: |
-  #      sudo apt-get update
-  #      sudo apt-get install cmake devscripts debhelper
+        docker-image: debian:${{ matrix.dist }}-slim
+        buildpackage-opts: --build=binary --no-sign
+        before-build-hook: debchange --controlmaint --local "+${{ github.sha }}~${{ matrix.dist }}" -b --distribution ${{ matrix.dist }} "CI build"
+        extra-build-deps: devscripts git
 
-  #      LATEST_TAG=$(git describe --tags)
-  #      BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    - name: Upload package
+      uses: actions/upload-artifact@v3
+      with:
+        name: pboted_${{ matrix.dist }}
+        path: debian/artifacts/pboted_*.deb
 
-  #      debchange -v "$LATEST_TAG-bullseye" -M --distribution bullseye "trunk build"
-  #      git archive --format=tar.gz -9 --worktree-attributes --prefix=pboted_$LATEST_TAG/ \
-  #        $BRANCH -o ../pboted_$LATEST_TAG.orig.tar.gz
-  #  - name: Build package
-  #    uses: legoktm/gh-action-build-deb@debian-bullseye
-  #    id: build
-  #    with:
-  #      args: --unsigned-source --unsigned-changes
-  #  - name: Upload artifact
-  #    uses: actions/upload-artifact@v1
-  #    with:
-  #      name: Packages for bullseye
-  #      path: output
+    - name: Upload debugging symbols
+      uses: actions/upload-artifact@v3
+      with:
+        name: pboted-dbgsym_${{ matrix.dist }}
+        path: debian/artifacts/pboted-dbgsym_*.deb

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         cd build
         cmake -G "MSYS Makefiles" -DMIMETIC_LIBRARY=../lib/compat-win/${{ matrix.arch_short }}/lib/libmimetic.a -DMIMETIC_INCLUDE_DIR=../lib/compat-win/include -DWITH_STATIC=ON .
-        make -j$(nproc)
+        cmake --build . -j$(nproc)
     - name: Upload binary
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -32,12 +32,12 @@ jobs:
         cmake -G "MSYS Makefiles" -DMIMETIC_LIBRARY=../lib/compat-win/${{ matrix.arch_short }}/lib/libmimetic.a -DMIMETIC_INCLUDE_DIR=../lib/compat-win/include -DWITH_STATIC=ON .
         make -j$(nproc)
     - name: Upload binary
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pboted-${{ matrix.arch_short }}
         path: build/pboted.exe
     - name: Upload debug symbols
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pboted-${{ matrix.arch_short }}-debug
         path: build/pboted.exe.debug

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -36,8 +36,8 @@ jobs:
       with:
         name: pboted-${{ matrix.arch_short }}
         path: build/pboted.exe
-    - name: Upload debug symbols
-      uses: actions/upload-artifact@v3
-      with:
-        name: pboted-${{ matrix.arch_short }}-debug
-        path: build/pboted.exe.debug
+    #- name: Upload debug symbols
+    #  uses: actions/upload-artifact@v3
+    #  with:
+    #    name: pboted-${{ matrix.arch_short }}-debug
+    #    path: build/pboted.exe.debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     name: CMake build
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout  
+    - name: Checkout
       uses: actions/checkout@v3
     - name: Install required packages
       run: |

--- a/src/FileSystem.h
+++ b/src/FileSystem.h
@@ -15,6 +15,7 @@
 #define DEFAULT_FILE_EXTENSION ".dat"
 #define DELETED_FILE_EXTENSION ".del"
 
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
## What's Changed

* Updated deb packages CI workflow to build packages for buster, bullseye, bookworm
* Fixed build on Windows MSYS2 with GCC 13

<!-- You can erase any follow  parts of this template not applicable to your Pull Request. -->

## Issue ticket number and link

#33
